### PR TITLE
Add full aliasing of starlette responses under eggman module

### DIFF
--- a/eggman/__init__.py
+++ b/eggman/__init__.py
@@ -1,5 +1,29 @@
-from eggman.alias import Request, Response, WebSocket
+from eggman.alias import (
+    FileResponse,
+    HTMLResponse,
+    JSONResponse,
+    PlainTextResponse,
+    RedirectResponse,
+    Request,
+    Response,
+    StreamingResponse,
+    UJSONResponse,
+    WebSocket,
+)
 from eggman.blueprint import Blueprint
 from eggman.server import Server
 
-__all__ = ["Blueprint", "Server"]
+__all__ = [
+    "Blueprint",
+    "Server",
+    "Request",
+    "Response",
+    "WebSocket",
+    "HTMLResponse",
+    "PlainTextResponse",
+    "JSONResponse",
+    "UJSONResponse",
+    "RedirectResponse",
+    "StreamingResponse",
+    "FileResponse",
+]

--- a/eggman/alias.py
+++ b/eggman/alias.py
@@ -1,7 +1,15 @@
-from starlette.requests import Request as StarletteRequest
-from starlette.responses import Response as StarletteResponse
-from starlette.websockets import WebSocket as StarletteWebSocket
+import starlette.requests as starlette_requests
+import starlette.responses as starlette_responses
+import starlette.websockets as starlette_websockets
 
-Request = StarletteRequest
-Response = StarletteResponse
-WebSocket = StarletteWebSocket
+Request = starlette_requests.Request
+Response = starlette_responses.Response
+WebSocket = starlette_websockets.WebSocket
+
+HTMLResponse = starlette_responses.HTMLResponse
+PlainTextResponse = starlette_responses.Response
+JSONResponse = starlette_responses.JSONResponse
+UJSONResponse = starlette_responses.UJSONResponse
+RedirectResponse = starlette_responses.RedirectResponse
+StreamingResponse = starlette_responses.StreamingResponse
+FileResponse = starlette_responses.FileResponse

--- a/eggman/tests/test_blueprint.py
+++ b/eggman/tests/test_blueprint.py
@@ -4,11 +4,10 @@ import asyncio
 
 import jab
 from starlette.applications import Starlette
-from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
 from typing_extensions import Protocol
 
-from eggman import Blueprint, Request, Response, Server, WebSocket
+from eggman import Blueprint, Request, Response, Server, WebSocket, PlainTextResponse
 
 
 class GetIncr(Protocol):

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+import sys
+from distutils.core import setup
+
+if sys.version_info.major < 3:
+    raise Exception("jab only works with Python 3.7+")
+
+if sys.version_info.major == 3 and sys.version_info.minor < 7:
+    raise Exception("jab only works with Python 3.7+")
+
+
+VERSION = "0.1.0"
+
+DEPENDENCIES = ["typing_extensions", "starlette", "jab"]
+DEP_LINKS = ["git+https://github.com/stntngo/jab@master#egg=jab"]
+
+setup(
+    name="eggman",
+    author="Niels Lindgren",
+    version=VERSION,
+    packages=["eggman"],
+    platforms="ANY",
+    url="https://github.com/stntngo/eggman",
+    install_requires=DEPENDENCIES,
+    dependency_links=DEP_LINKS,
+)


### PR DESCRIPTION
Rather than having to import `starlette.responses` when defining the type annotations of your
handler functions, we alias all possible starlette requests and responses in order to provide a
simpler user experience.